### PR TITLE
Add SlackStream interface, implementation and factory to stream module

### DIFF
--- a/stream/src/commonMain/kotlin/work/socialhub/kslack/stream/SlackStream.kt
+++ b/stream/src/commonMain/kotlin/work/socialhub/kslack/stream/SlackStream.kt
@@ -1,0 +1,9 @@
+package work.socialhub.kslack.stream
+
+import kotlin.js.JsExport
+
+@JsExport
+interface SlackStream {
+
+    fun token(): String
+}

--- a/stream/src/commonMain/kotlin/work/socialhub/kslack/stream/SlackStreamFactory.kt
+++ b/stream/src/commonMain/kotlin/work/socialhub/kslack/stream/SlackStreamFactory.kt
@@ -1,0 +1,17 @@
+package work.socialhub.kslack.stream
+
+import work.socialhub.kslack.stream.internal.SlackStreamImpl
+import kotlin.js.JsExport
+
+@JsExport
+object SlackStreamFactory {
+
+    /**
+     * get SlackStream instance
+     */
+    fun instance(
+        token: String = "",
+    ): SlackStream {
+        return SlackStreamImpl(token)
+    }
+}

--- a/stream/src/commonMain/kotlin/work/socialhub/kslack/stream/internal/SlackStreamImpl.kt
+++ b/stream/src/commonMain/kotlin/work/socialhub/kslack/stream/internal/SlackStreamImpl.kt
@@ -1,0 +1,10 @@
+package work.socialhub.kslack.stream.internal
+
+import work.socialhub.kslack.stream.SlackStream
+
+class SlackStreamImpl(
+    private val token: String,
+) : SlackStream {
+
+    override fun token() = token
+}


### PR DESCRIPTION
Add placeholder source files to fix publish failure on macOS CI where native targets are enabled but no .klib artifacts are produced due to missing source code.