### PR TITLE
chore: remove unused kotlinx-datetime dependency

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -46,7 +46,6 @@ kotlin {
             implementation(libs.ktor.core)
             implementation(libs.kmpcommon)
             implementation(libs.khttpclient)
-            implementation(libs.datetime)
             implementation(libs.serialization.json)
         }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,6 @@ coroutines = "1.11.0"
 kmpcommon = "work.socialhub:kmpcommon:0.0.1-SNAPSHOT"
 khttpclient = "work.socialhub:khttpclient:0.0.8"
 ktor-core = "io.ktor:ktor-client-core:3.4.3"
-datetime = "org.jetbrains.kotlinx:kotlinx-datetime:0.8.0-0.6.x-compat"
 coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }


### PR DESCRIPTION
kotlinx-datetime was declared as a dependency but never imported in source code. kotlin.time.Clock/Instant from stdlib is sufficient.