### PR TITLE
ci: copy JS docs to npm package output

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -25,6 +25,11 @@ jobs:
           project_version=$(./gradlew version --no-daemon --console=plain -q)
           echo "PROJECT_VERSION=$project_version" >> $GITHUB_ENV
 
+      - name: Copy Docs to Npm Package
+        run: |
+          cp ./docs/js/README.md ./all/build/dist/js/productionLibrary/README.md
+          cp ./docs/js/README_ja.md ./all/build/dist/js/productionLibrary/README_ja.md
+
       - name: Commit Pods to GitHub
         if: github.ref == 'refs/heads/main'
         run: |


### PR DESCRIPTION
Copy the README from `docs/js/` to `productionLibrary`,
so that the npm repository includes the documentation