### PR TITLE
Revert "Remove deprecated macosX64 target"

### DIFF
--- a/all/build.gradle.kts
+++ b/all/build.gradle.kts
@@ -12,7 +12,7 @@ kotlin {
     jvmToolchain(11)
     jvm()
 
-    js {
+    js(IR) {
         nodejs()
         browser()
         binaries.library()
@@ -27,6 +27,7 @@ kotlin {
         iosX64(),
         iosArm64(),
         iosSimulatorArm64(),
+        macosX64(),
         macosArm64(),
     ).forEach {
         it.binaries.framework {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -15,7 +15,7 @@ kotlin {
         }
     }
 
-    js {
+    js(IR) {
         nodejs()
         browser()
         compilerOptions {
@@ -27,6 +27,7 @@ kotlin {
         iosX64()
         iosArm64()
         iosSimulatorArm64()
+        macosX64()
         macosArm64()
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,4 +20,3 @@ mavenCentralAutomaticPublishing=true
 # Java Toolchain Auto-Provisioning
 org.gradle.java.installations.auto-detect=true
 org.gradle.java.installations.auto-download=true
-kotlin.native.ignoreDisabledTargets=true

--- a/stream/build.gradle.kts
+++ b/stream/build.gradle.kts
@@ -15,7 +15,7 @@ kotlin {
         }
     }
 
-    js {
+    js(IR) {
         nodejs()
         browser()
     }
@@ -24,6 +24,7 @@ kotlin {
         iosX64()
         iosArm64()
         iosSimulatorArm64()
+        macosX64()
         macosArm64()
     }
 


### PR DESCRIPTION
Reverts uakihir0/kslack#46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated JavaScript build configuration to use IR backend across Kotlin multiplatform targets.
  * Added Intel-based macOS (X64) target support to complement existing Apple Silicon and iOS builds.
  * Cleaned up deprecated build settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->