### PR TITLE
feat: make API endpoint URL configurable via apiUrl parameter

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kslack/SlackFactory.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kslack/SlackFactory.kt
@@ -65,4 +65,19 @@ object SlackFactory {
     ): Slack {
         return SlackImpl(token)
     }
+
+    /**
+     * Creates a Slack API client with a custom endpoint URL prefix.
+     *
+     * @param token The OAuth access token (null for unauthenticated calls)
+     * @param apiUrl Custom base URL for API requests
+     * @return A new [Slack] instance configured with the given token and endpoint
+     */
+    @JsName("createInstanceWithTokenAndHost")
+    fun instance(
+        token: String?,
+        apiUrl: String,
+    ): Slack {
+        return SlackImpl(token, apiUrl)
+    }
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kslack/SlackFactory.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kslack/SlackFactory.kt
@@ -65,4 +65,20 @@ object SlackFactory {
     ): Slack {
         return SlackImpl(token)
     }
+
+    /**
+     * Creates a Slack API client with a default authentication token
+     * and a custom endpoint URL prefix.
+     *
+     * @param token The OAuth access token
+     * @param apiUrl Custom base URL for API requests
+     * @return A new [Slack] instance configured with the given token and endpoint
+     */
+    @JsName("createInstanceWithTokenAndHost")
+    fun instance(
+        token: String,
+        apiUrl: String,
+    ): Slack {
+        return SlackImpl(token, apiUrl)
+    }
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kslack/api/methods/impl/AbstractResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kslack/api/methods/impl/AbstractResourceImpl.kt
@@ -47,7 +47,8 @@ open class AbstractResourceImpl(
      * Set when creating the resource via [SlackFactory].
      * Can be overridden by providing a token in individual requests.
      */
-    val token: String?
+    val token: String?,
+    val apiUrl: String = Slack.ENDPOINT_URL_PREFIX
 ) {
 
     // ----------------------------------------------
@@ -68,7 +69,7 @@ open class AbstractResourceImpl(
         endpoint: String,
     ): HttpResponse {
         return HttpRequest()
-            .url("${Slack.ENDPOINT_URL_PREFIX}$endpoint")
+            .url("${apiUrl}$endpoint")
             .also { it.params += params }
             .forceApplicationFormUrlEncoded(true)
             .post()
@@ -89,7 +90,7 @@ open class AbstractResourceImpl(
         token: String,
     ): HttpResponse {
         return HttpRequest()
-            .url("${Slack.ENDPOINT_URL_PREFIX}$endpoint")
+            .url("${apiUrl}$endpoint")
             .also { it.params += params }
             .header("Authorization", "Bearer $token")
             .forceApplicationFormUrlEncoded(true)
@@ -111,7 +112,7 @@ open class AbstractResourceImpl(
         token: String,
     ): HttpResponse {
         return HttpRequest()
-            .url("${Slack.ENDPOINT_URL_PREFIX}$endpoint")
+            .url("${apiUrl}$endpoint")
             .also { it.params += params }
             .header("Authorization", "Bearer $token")
             .forceMultipartFormData(true)

--- a/core/src/commonMain/kotlin/work/socialhub/kslack/internal/SlackImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kslack/internal/SlackImpl.kt
@@ -85,40 +85,41 @@ class SlackImpl(
      * Can be null if tokens are provided per-request.
      */
     override val token: String? = null,
+    private val apiUrl: String = Slack.ENDPOINT_URL_PREFIX,
 ) : Slack {
 
     // ----------------------------------------------
     // Resource implementations (eagerly initialized)
     // ----------------------------------------------
 
-    private val admin: AdminResource = AdminResourceImpl(token)
-    private val adminConversations: AdminConversationsResource = AdminConversationsResourceImpl(token)
-    private val api: ApiResource = ApiResourceImpl(token)
-    private val apps: AppsResource = AppsResourceImpl(token)
-    private val auth: AuthResource = AuthResourceImpl(token)
-    private val bookmarks: BookmarksResource = BookmarksResourceImpl(token)
-    private val bots: BotsResource = BotsResourceImpl(token)
-    private val calls: CallsResource = CallsResourceImpl(token)
-    private val chat: ChatResource = ChatResourceImpl(token)
-    private val conversations: ConversationsResource = ConversationsResourceImpl(token)
-    private val dialog: DialogResource = DialogResourceImpl(token)
-    private val dnd: DndResource = DndResourceImpl(token)
-    private val emoji: EmojiResource = EmojiResourceImpl(token)
-    private val files: FilesResource = FilesResourceImpl(token)
-    private val migration: MigrationResource = MigrationResourceImpl(token)
+    private val admin: AdminResource = AdminResourceImpl(token, apiUrl)
+    private val adminConversations: AdminConversationsResource = AdminConversationsResourceImpl(token, apiUrl)
+    private val api: ApiResource = ApiResourceImpl(token, apiUrl)
+    private val apps: AppsResource = AppsResourceImpl(token, apiUrl)
+    private val auth: AuthResource = AuthResourceImpl(token, apiUrl)
+    private val bookmarks: BookmarksResource = BookmarksResourceImpl(token, apiUrl)
+    private val bots: BotsResource = BotsResourceImpl(token, apiUrl)
+    private val calls: CallsResource = CallsResourceImpl(token, apiUrl)
+    private val chat: ChatResource = ChatResourceImpl(token, apiUrl)
+    private val conversations: ConversationsResource = ConversationsResourceImpl(token, apiUrl)
+    private val dialog: DialogResource = DialogResourceImpl(token, apiUrl)
+    private val dnd: DndResource = DndResourceImpl(token, apiUrl)
+    private val emoji: EmojiResource = EmojiResourceImpl(token, apiUrl)
+    private val files: FilesResource = FilesResourceImpl(token, apiUrl)
+    private val migration: MigrationResource = MigrationResourceImpl(token, apiUrl)
     private val oauth: OAuthResource = OAuthResourceImpl()
-    private val openIDConnect: OpenIDConnectResource = OpenIDConnectResourceImpl(token)
-    private val pins: PinsResource = PinsResourceImpl(token)
-    private val reactions: ReactionsResource = ReactionsResourceImpl(token)
-    private val reminders: RemindersResource = RemindersResourceImpl(token)
-    private val search: SearchResource = SearchResourceImpl(token)
-    private val stars: StarsResource = StarsResourceImpl(token)
+    private val openIDConnect: OpenIDConnectResource = OpenIDConnectResourceImpl(token, apiUrl)
+    private val pins: PinsResource = PinsResourceImpl(token, apiUrl)
+    private val reactions: ReactionsResource = ReactionsResourceImpl(token, apiUrl)
+    private val reminders: RemindersResource = RemindersResourceImpl(token, apiUrl)
+    private val search: SearchResource = SearchResourceImpl(token, apiUrl)
+    private val stars: StarsResource = StarsResourceImpl(token, apiUrl)
     private val status: StatusResource = StatusResourceImpl()
-    private val team: TeamResource = TeamResourceImpl(token)
-    private val usergroups: UsergroupsResource = UsergroupsResourceImpl(token)
-    private val users: UsersResource = UsersResourceImpl(token)
-    private val views: ViewsResource = ViewsResourceImpl(token)
-    private val workflows: WorkflowsResource = WorkflowsResourceImpl(token)
+    private val team: TeamResource = TeamResourceImpl(token, apiUrl)
+    private val usergroups: UsergroupsResource = UsergroupsResourceImpl(token, apiUrl)
+    private val users: UsersResource = UsersResourceImpl(token, apiUrl)
+    private val views: ViewsResource = ViewsResourceImpl(token, apiUrl)
+    private val workflows: WorkflowsResource = WorkflowsResourceImpl(token, apiUrl)
 
     // ----------------------------------------------
     // Streaming resource (lazily initialized)
@@ -126,7 +127,7 @@ class SlackImpl(
 
     private val streamInstance: SlackStream by lazy {
         val t = token ?: throw IllegalStateException("Token is required for streaming. Use SlackFactory.instance(token) to create a Slack instance with a token.")
-        SlackStreamImpl(t)
+        SlackStreamImpl(t, apiUrl)
     }
 
     // ----------------------------------------------

--- a/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/AdminConversationsResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/AdminConversationsResourceImpl.kt
@@ -1,5 +1,7 @@
 package work.socialhub.kslack.internal.api
 
+import work.socialhub.kslack.Slack
+
 import work.socialhub.kslack.api.AdminConversationsResource
 import work.socialhub.kslack.api.methods.Methods
 import work.socialhub.kslack.api.methods.impl.AbstractResourceImpl
@@ -21,8 +23,9 @@ import work.socialhub.kslack.util.toBlocking
  * @param token Optional default token provided at factory initialization
  */
 class AdminConversationsResourceImpl(
-    token: String?
-) : AbstractResourceImpl(token),
+    token: String?,
+    apiUrl: String = Slack.ENDPOINT_URL_PREFIX,
+) : AbstractResourceImpl(token, apiUrl),
     AdminConversationsResource {
 
     override suspend fun adminConversationsCreate(

--- a/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/AdminResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/AdminResourceImpl.kt
@@ -1,5 +1,7 @@
 package work.socialhub.kslack.internal.api
 
+import work.socialhub.kslack.Slack
+
 import work.socialhub.kslack.api.AdminResource
 import work.socialhub.kslack.api.methods.Methods
 import work.socialhub.kslack.api.methods.impl.AbstractResourceImpl
@@ -32,8 +34,9 @@ import work.socialhub.kslack.util.toBlocking
  * @param token Optional default token provided at factory initialization
  */
 class AdminResourceImpl(
-    token: String?
-) : AbstractResourceImpl(token),
+    token: String?,
+    apiUrl: String = Slack.ENDPOINT_URL_PREFIX,
+) : AbstractResourceImpl(token, apiUrl),
     AdminResource {
 
     override suspend fun adminAppsApprove(

--- a/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/ApiResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/ApiResourceImpl.kt
@@ -1,5 +1,7 @@
 package work.socialhub.kslack.internal.api
 
+import work.socialhub.kslack.Slack
+
 import work.socialhub.kslack.api.ApiResource
 import work.socialhub.kslack.api.methods.Methods
 import work.socialhub.kslack.api.methods.impl.AbstractResourceImpl
@@ -19,8 +21,9 @@ import work.socialhub.kslack.util.toBlocking
  * @param token Optional default token provided at factory initialization
  */
 class ApiResourceImpl(
-    token: String?
-) : AbstractResourceImpl(token), ApiResource {
+    token: String?,
+    apiUrl: String = Slack.ENDPOINT_URL_PREFIX,
+) : AbstractResourceImpl(token, apiUrl), ApiResource {
 
     override suspend fun apiTest(req: ApiTestRequest): ApiTestResponse {
         return postForm(req.toParams(), Methods.API_TEST)

--- a/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/AppsResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/AppsResourceImpl.kt
@@ -1,5 +1,7 @@
 package work.socialhub.kslack.internal.api
 
+import work.socialhub.kslack.Slack
+
 import work.socialhub.kslack.api.AppsResource
 import work.socialhub.kslack.api.methods.Methods
 import work.socialhub.kslack.api.methods.impl.AbstractResourceImpl
@@ -18,8 +20,9 @@ import work.socialhub.kslack.util.toBlocking
  * @param token Optional default token provided at factory initialization
  */
 class AppsResourceImpl(
-    token: String?
-) : AbstractResourceImpl(token), AppsResource {
+    token: String?,
+    apiUrl: String = Slack.ENDPOINT_URL_PREFIX,
+) : AbstractResourceImpl(token, apiUrl), AppsResource {
 
     override suspend fun appsConnectionsOpen(
         req: AppsConnectionsOpenRequest

--- a/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/AuthResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/AuthResourceImpl.kt
@@ -28,8 +28,9 @@ import work.socialhub.kslack.util.toBlocking
  * @param token Optional default token provided at factory initialization
  */
 class AuthResourceImpl(
-    token: String?
-) : AbstractResourceImpl(token), AuthResource {
+    token: String?,
+    apiUrl: String = Slack.ENDPOINT_URL_PREFIX,
+) : AbstractResourceImpl(token, apiUrl), AuthResource {
 
     override suspend fun authRevoke(req: AuthRevokeRequest): AuthRevokeResponse {
         return postFormWithToken(req.toParams(), Methods.AUTH_REVOKE, getToken(req))

--- a/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/BookmarksResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/BookmarksResourceImpl.kt
@@ -1,5 +1,7 @@
 package work.socialhub.kslack.internal.api
 
+import work.socialhub.kslack.Slack
+
 import work.socialhub.kslack.api.BookmarksResource
 import work.socialhub.kslack.api.methods.Methods
 import work.socialhub.kslack.api.methods.impl.AbstractResourceImpl
@@ -16,8 +18,9 @@ import work.socialhub.kslack.util.toBlocking
  * @param token Optional default token provided at factory initialization
  */
 class BookmarksResourceImpl(
-    token: String?
-) : AbstractResourceImpl(token), BookmarksResource {
+    token: String?,
+    apiUrl: String = Slack.ENDPOINT_URL_PREFIX,
+) : AbstractResourceImpl(token, apiUrl), BookmarksResource {
 
     override suspend fun bookmarksAdd(
         req: BookmarksAddRequest

--- a/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/BotsResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/BotsResourceImpl.kt
@@ -1,5 +1,7 @@
 package work.socialhub.kslack.internal.api
 
+import work.socialhub.kslack.Slack
+
 import work.socialhub.kslack.api.BotsResource
 import work.socialhub.kslack.api.methods.Methods
 import work.socialhub.kslack.api.methods.impl.AbstractResourceImpl
@@ -16,8 +18,9 @@ import work.socialhub.kslack.util.toBlocking
  * @param token Optional default token provided at factory initialization
  */
 class BotsResourceImpl(
-    token: String?
-) : AbstractResourceImpl(token), BotsResource {
+    token: String?,
+    apiUrl: String = Slack.ENDPOINT_URL_PREFIX,
+) : AbstractResourceImpl(token, apiUrl), BotsResource {
 
     override suspend fun botsInfo(req: BotsInfoRequest): BotsInfoResponse {
         return postFormWithToken(req.toParams(), Methods.BOTS_INFO, getToken(req))

--- a/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/CallsResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/CallsResourceImpl.kt
@@ -1,5 +1,7 @@
 package work.socialhub.kslack.internal.api
 
+import work.socialhub.kslack.Slack
+
 import work.socialhub.kslack.api.CallsResource
 import work.socialhub.kslack.api.methods.Methods
 import work.socialhub.kslack.api.methods.impl.AbstractResourceImpl
@@ -21,8 +23,9 @@ import work.socialhub.kslack.util.toBlocking
  * @param token Optional default token provided at factory initialization
  */
 class CallsResourceImpl(
-    token: String?
-) : AbstractResourceImpl(token), CallsResource {
+    token: String?,
+    apiUrl: String = Slack.ENDPOINT_URL_PREFIX,
+) : AbstractResourceImpl(token, apiUrl), CallsResource {
 
     override suspend fun callsAdd(
         req: CallsAddRequest

--- a/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/ChatResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/ChatResourceImpl.kt
@@ -1,5 +1,7 @@
 package work.socialhub.kslack.internal.api
 
+import work.socialhub.kslack.Slack
+
 import work.socialhub.kslack.api.ChatResource
 import work.socialhub.kslack.api.methods.Methods
 import work.socialhub.kslack.api.methods.impl.AbstractResourceImpl
@@ -28,8 +30,9 @@ import work.socialhub.kslack.util.toBlocking
  * @param token Optional default token provided at factory initialization
  */
 class ChatResourceImpl(
-    token: String?
-) : AbstractResourceImpl(token),
+    token: String?,
+    apiUrl: String = Slack.ENDPOINT_URL_PREFIX,
+) : AbstractResourceImpl(token, apiUrl),
     ChatResource {
 
     override suspend fun chatGetPermalink(

--- a/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/ConversationsResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/ConversationsResourceImpl.kt
@@ -1,5 +1,7 @@
 package work.socialhub.kslack.internal.api
 
+import work.socialhub.kslack.Slack
+
 import work.socialhub.kslack.api.ConversationsResource
 import work.socialhub.kslack.api.methods.Methods
 import work.socialhub.kslack.api.methods.impl.AbstractResourceImpl
@@ -25,8 +27,9 @@ import work.socialhub.kslack.util.toBlocking
  * @param token Optional default token provided at factory initialization
  */
 class ConversationsResourceImpl(
-    token: String?
-) : AbstractResourceImpl(token),
+    token: String?,
+    apiUrl: String = Slack.ENDPOINT_URL_PREFIX,
+) : AbstractResourceImpl(token, apiUrl),
     ConversationsResource {
 
     override suspend fun conversationsArchive(

--- a/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/DialogResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/DialogResourceImpl.kt
@@ -1,5 +1,7 @@
 package work.socialhub.kslack.internal.api
 
+import work.socialhub.kslack.Slack
+
 import work.socialhub.kslack.api.DialogResource
 import work.socialhub.kslack.api.methods.Methods
 import work.socialhub.kslack.api.methods.impl.AbstractResourceImpl
@@ -19,8 +21,9 @@ import work.socialhub.kslack.util.toBlocking
  */
 @Deprecated("Use ViewsResource (views.open) for modals instead.")
 class DialogResourceImpl(
-    token: String?
-) : AbstractResourceImpl(token), DialogResource {
+    token: String?,
+    apiUrl: String = Slack.ENDPOINT_URL_PREFIX,
+) : AbstractResourceImpl(token, apiUrl), DialogResource {
 
     @Deprecated("Use ViewsResource (views.open) for modals instead.")
     override suspend fun dialogOpen(req: DialogOpenRequest): DialogOpenResponse {

--- a/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/DndResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/DndResourceImpl.kt
@@ -1,5 +1,7 @@
 package work.socialhub.kslack.internal.api
 
+import work.socialhub.kslack.Slack
+
 import work.socialhub.kslack.api.DndResource
 import work.socialhub.kslack.api.methods.Methods
 import work.socialhub.kslack.api.methods.impl.AbstractResourceImpl
@@ -16,8 +18,9 @@ import work.socialhub.kslack.util.toBlocking
  * @param token Optional default token provided at factory initialization
  */
 class DndResourceImpl(
-    token: String?
-) : AbstractResourceImpl(token), DndResource {
+    token: String?,
+    apiUrl: String = Slack.ENDPOINT_URL_PREFIX,
+) : AbstractResourceImpl(token, apiUrl), DndResource {
 
     override suspend fun dndEndDnd(req: DndEndDndRequest): DndEndDndResponse {
         return postFormWithToken(req.toParams(), Methods.DND_END_DND, getToken(req))

--- a/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/EmojiResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/EmojiResourceImpl.kt
@@ -1,5 +1,7 @@
 package work.socialhub.kslack.internal.api
 
+import work.socialhub.kslack.Slack
+
 import work.socialhub.kslack.api.EmojiResource
 import work.socialhub.kslack.api.methods.Methods
 import work.socialhub.kslack.api.methods.impl.AbstractResourceImpl
@@ -16,8 +18,9 @@ import work.socialhub.kslack.util.toBlocking
  * @param token Optional default token provided at factory initialization
  */
 class EmojiResourceImpl(
-    token: String?
-) : AbstractResourceImpl(token), EmojiResource {
+    token: String?,
+    apiUrl: String = Slack.ENDPOINT_URL_PREFIX,
+) : AbstractResourceImpl(token, apiUrl), EmojiResource {
 
     override suspend fun emojiList(req: EmojiListRequest): EmojiListResponse {
         return postFormWithToken(req.toParams(), Methods.EMOJI_LIST, getToken(req))

--- a/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/FilesResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/FilesResourceImpl.kt
@@ -1,5 +1,7 @@
 package work.socialhub.kslack.internal.api
 
+import work.socialhub.kslack.Slack
+
 import work.socialhub.kslack.api.FilesResource
 import work.socialhub.kslack.api.methods.Methods
 import work.socialhub.kslack.api.methods.impl.AbstractResourceImpl
@@ -20,8 +22,9 @@ import work.socialhub.kslack.util.toBlocking
  * @param token Optional default token provided at factory initialization
  */
 class FilesResourceImpl(
-    token: String?
-) : AbstractResourceImpl(token),
+    token: String?,
+    apiUrl: String = Slack.ENDPOINT_URL_PREFIX,
+) : AbstractResourceImpl(token, apiUrl),
     FilesResource {
 
     override suspend fun filesDelete(

--- a/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/MigrationResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/MigrationResourceImpl.kt
@@ -1,5 +1,7 @@
 package work.socialhub.kslack.internal.api
 
+import work.socialhub.kslack.Slack
+
 import work.socialhub.kslack.api.MigrationResource
 import work.socialhub.kslack.api.methods.Methods
 import work.socialhub.kslack.api.methods.impl.AbstractResourceImpl
@@ -16,8 +18,9 @@ import work.socialhub.kslack.util.toBlocking
  * @param token Optional default token provided at factory initialization
  */
 class MigrationResourceImpl(
-    token: String?
-) : AbstractResourceImpl(token), MigrationResource {
+    token: String?,
+    apiUrl: String = Slack.ENDPOINT_URL_PREFIX,
+) : AbstractResourceImpl(token, apiUrl), MigrationResource {
 
     override suspend fun migrationExchange(req: MigrationExchangeRequest): MigrationExchangeResponse {
         return postFormWithToken(req.toParams(), Methods.MIGRATION_EXCHANGE, getToken(req))

--- a/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/OpenIDConnectResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/OpenIDConnectResourceImpl.kt
@@ -1,5 +1,7 @@
 package work.socialhub.kslack.internal.api
 
+import work.socialhub.kslack.Slack
+
 import work.socialhub.kslack.api.OpenIDConnectResource
 import work.socialhub.kslack.api.methods.Methods
 import work.socialhub.kslack.api.methods.impl.AbstractResourceImpl
@@ -17,8 +19,9 @@ import work.socialhub.kslack.util.toBlocking
  * @param token Optional default token for the userInfo method (token method uses client credentials)
  */
 class OpenIDConnectResourceImpl(
-    token: String?
-) : AbstractResourceImpl(token), OpenIDConnectResource {
+    token: String?,
+    apiUrl: String = Slack.ENDPOINT_URL_PREFIX,
+) : AbstractResourceImpl(token, apiUrl), OpenIDConnectResource {
 
     override suspend fun openIDConnectToken(
         req: OpenIDConnectTokenRequest

--- a/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/PinsResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/PinsResourceImpl.kt
@@ -1,5 +1,7 @@
 package work.socialhub.kslack.internal.api
 
+import work.socialhub.kslack.Slack
+
 import work.socialhub.kslack.api.PinsResource
 import work.socialhub.kslack.api.methods.Methods
 import work.socialhub.kslack.api.methods.impl.AbstractResourceImpl
@@ -22,8 +24,9 @@ import work.socialhub.kslack.util.toBlocking
  * @param token Optional default token provided at factory initialization
  */
 class PinsResourceImpl(
-    token: String?
-) : AbstractResourceImpl(token), PinsResource {
+    token: String?,
+    apiUrl: String = Slack.ENDPOINT_URL_PREFIX,
+) : AbstractResourceImpl(token, apiUrl), PinsResource {
 
     override suspend fun pinsAdd(
         req: PinsAddRequest

--- a/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/ReactionsResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/ReactionsResourceImpl.kt
@@ -1,5 +1,7 @@
 package work.socialhub.kslack.internal.api
 
+import work.socialhub.kslack.Slack
+
 import work.socialhub.kslack.api.ReactionsResource
 import work.socialhub.kslack.api.methods.Methods
 import work.socialhub.kslack.api.methods.impl.AbstractResourceImpl
@@ -22,8 +24,9 @@ import work.socialhub.kslack.util.toBlocking
  * @param token Optional default token provided at factory initialization
  */
 class ReactionsResourceImpl(
-    token: String?
-) : AbstractResourceImpl(token), ReactionsResource {
+    token: String?,
+    apiUrl: String = Slack.ENDPOINT_URL_PREFIX,
+) : AbstractResourceImpl(token, apiUrl), ReactionsResource {
 
     override suspend fun reactionsAdd(
         req: ReactionsAddRequest

--- a/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/RemindersResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/RemindersResourceImpl.kt
@@ -1,5 +1,7 @@
 package work.socialhub.kslack.internal.api
 
+import work.socialhub.kslack.Slack
+
 import work.socialhub.kslack.api.RemindersResource
 import work.socialhub.kslack.api.methods.Methods
 import work.socialhub.kslack.api.methods.impl.AbstractResourceImpl
@@ -16,8 +18,9 @@ import work.socialhub.kslack.util.toBlocking
  * @param token Optional default token provided at factory initialization
  */
 class RemindersResourceImpl(
-    token: String?
-) : AbstractResourceImpl(token), RemindersResource {
+    token: String?,
+    apiUrl: String = Slack.ENDPOINT_URL_PREFIX,
+) : AbstractResourceImpl(token, apiUrl), RemindersResource {
 
     override suspend fun remindersAdd(req: RemindersAddRequest): RemindersAddResponse {
         return postFormWithToken(req.toParams(), Methods.REMINDERS_ADD, getToken(req))

--- a/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/SearchResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/SearchResourceImpl.kt
@@ -1,5 +1,7 @@
 package work.socialhub.kslack.internal.api
 
+import work.socialhub.kslack.Slack
+
 import work.socialhub.kslack.api.SearchResource
 import work.socialhub.kslack.api.methods.Methods
 import work.socialhub.kslack.api.methods.impl.AbstractResourceImpl
@@ -20,8 +22,9 @@ import work.socialhub.kslack.util.toBlocking
  * @param token Optional default token provided at factory initialization
  */
 class SearchResourceImpl(
-    token: String?
-) : AbstractResourceImpl(token), SearchResource {
+    token: String?,
+    apiUrl: String = Slack.ENDPOINT_URL_PREFIX,
+) : AbstractResourceImpl(token, apiUrl), SearchResource {
 
     override suspend fun searchAll(
         req: SearchAllRequest

--- a/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/StarsResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/StarsResourceImpl.kt
@@ -1,5 +1,7 @@
 package work.socialhub.kslack.internal.api
 
+import work.socialhub.kslack.Slack
+
 import work.socialhub.kslack.api.StarsResource
 import work.socialhub.kslack.api.methods.Methods
 import work.socialhub.kslack.api.methods.impl.AbstractResourceImpl
@@ -24,8 +26,9 @@ import work.socialhub.kslack.util.toBlocking
  */
 @Deprecated("Stars API is functionally deprecated. Replaced by Later view.")
 class StarsResourceImpl(
-    token: String?
-) : AbstractResourceImpl(token), StarsResource {
+    token: String?,
+    apiUrl: String = Slack.ENDPOINT_URL_PREFIX,
+) : AbstractResourceImpl(token, apiUrl), StarsResource {
 
     @Deprecated("Stars API is functionally deprecated. Replaced by Later view.")
     override suspend fun starsAdd(

--- a/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/TeamResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/TeamResourceImpl.kt
@@ -1,5 +1,7 @@
 package work.socialhub.kslack.internal.api
 
+import work.socialhub.kslack.Slack
+
 import work.socialhub.kslack.api.TeamResource
 import work.socialhub.kslack.api.methods.Methods
 import work.socialhub.kslack.api.methods.impl.AbstractResourceImpl
@@ -33,8 +35,9 @@ import work.socialhub.kslack.util.toBlocking
  * @param token Optional default token provided at factory initialization
  */
 class TeamResourceImpl(
-    token: String?
-) : AbstractResourceImpl(token), TeamResource {
+    token: String?,
+    apiUrl: String = Slack.ENDPOINT_URL_PREFIX,
+) : AbstractResourceImpl(token, apiUrl), TeamResource {
 
     override suspend fun teamAccessLogs(req: TeamAccessLogsRequest): TeamAccessLogsResponse {
         return postFormWithToken(req.toParams(), Methods.TEAM_ACCESS_LOGS, getToken(req))

--- a/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/UsergroupsResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/UsergroupsResourceImpl.kt
@@ -1,5 +1,7 @@
 package work.socialhub.kslack.internal.api
 
+import work.socialhub.kslack.Slack
+
 import work.socialhub.kslack.api.UsergroupsResource
 import work.socialhub.kslack.api.methods.Methods
 import work.socialhub.kslack.api.methods.impl.AbstractResourceImpl
@@ -20,8 +22,9 @@ import work.socialhub.kslack.util.toBlocking
  * @param token Optional default token provided at factory initialization
  */
 class UsergroupsResourceImpl(
-    token: String?
-) : AbstractResourceImpl(token), UsergroupsResource {
+    token: String?,
+    apiUrl: String = Slack.ENDPOINT_URL_PREFIX,
+) : AbstractResourceImpl(token, apiUrl), UsergroupsResource {
 
     override suspend fun usergroupsCreate(req: UsergroupsCreateRequest): UserGroupsCreateResponse {
         return postFormWithToken(req.toParams(), Methods.USERGROUPS_CREATE, getToken(req))

--- a/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/UsersResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/UsersResourceImpl.kt
@@ -1,5 +1,7 @@
 package work.socialhub.kslack.internal.api
 
+import work.socialhub.kslack.Slack
+
 import work.socialhub.kslack.api.UsersResource
 import work.socialhub.kslack.api.methods.Methods
 import work.socialhub.kslack.api.methods.impl.AbstractResourceImpl
@@ -21,8 +23,9 @@ import work.socialhub.kslack.util.toBlocking
  * @param token Optional default token provided at factory initialization
  */
 class UsersResourceImpl(
-    token: String?
-) : AbstractResourceImpl(token),
+    token: String?,
+    apiUrl: String = Slack.ENDPOINT_URL_PREFIX,
+) : AbstractResourceImpl(token, apiUrl),
     UsersResource {
 
     override suspend fun usersConversations(

--- a/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/ViewsResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/ViewsResourceImpl.kt
@@ -1,5 +1,7 @@
 package work.socialhub.kslack.internal.api
 
+import work.socialhub.kslack.Slack
+
 import work.socialhub.kslack.api.ViewsResource
 import work.socialhub.kslack.api.methods.Methods
 import work.socialhub.kslack.api.methods.impl.AbstractResourceImpl
@@ -24,8 +26,9 @@ import work.socialhub.kslack.util.toBlocking
  * @param token Optional default token provided at factory initialization
  */
 class ViewsResourceImpl(
-    token: String?
-) : AbstractResourceImpl(token), ViewsResource {
+    token: String?,
+    apiUrl: String = Slack.ENDPOINT_URL_PREFIX,
+) : AbstractResourceImpl(token, apiUrl), ViewsResource {
 
     override suspend fun viewsOpen(req: ViewsOpenRequest): ViewsOpenResponse {
         return postFormWithToken(req.toParams(), Methods.VIEWS_OPEN, getToken(req))

--- a/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/WorkflowsResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kslack/internal/api/WorkflowsResourceImpl.kt
@@ -1,5 +1,7 @@
 package work.socialhub.kslack.internal.api
 
+import work.socialhub.kslack.Slack
+
 import work.socialhub.kslack.api.methods.Methods
 import work.socialhub.kslack.api.WorkflowsResource
 import work.socialhub.kslack.api.methods.impl.AbstractResourceImpl
@@ -20,8 +22,9 @@ import work.socialhub.kslack.util.toBlocking
  * @param token Optional default token provided at factory initialization
  */
 class WorkflowsResourceImpl(
-    token: String?
-) : AbstractResourceImpl(token),
+    token: String?,
+    apiUrl: String = Slack.ENDPOINT_URL_PREFIX,
+) : AbstractResourceImpl(token, apiUrl),
     WorkflowsResource {
 
     override suspend fun workflowsStepsComplete(

--- a/core/src/commonMain/kotlin/work/socialhub/kslack/stream/internal/SlackStreamImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kslack/stream/internal/SlackStreamImpl.kt
@@ -2,15 +2,17 @@ package work.socialhub.kslack.stream.internal
 
 import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import work.socialhub.kslack.Slack
 import work.socialhub.kslack.stream.SlackStream
 import work.socialhub.kslack.stream.SlackStreamListener
 
 @OptIn(ExperimentalAtomicApi::class)
 class SlackStreamImpl(
     private val token: String?,
+    private val apiUrl: String = Slack.ENDPOINT_URL_PREFIX,
 ) : SlackStream, SlackStreamListener {
 
-    private val client = SocketModeClient(token ?: "", this)
+    private val client = SocketModeClient(token ?: "", this, apiUrl)
     private val listenersRef = AtomicReference(emptyList<SlackStreamListener>())
 
     override fun token(): String {

--- a/core/src/commonMain/kotlin/work/socialhub/kslack/stream/internal/SocketModeClient.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kslack/stream/internal/SocketModeClient.kt
@@ -1,5 +1,6 @@
 package work.socialhub.kslack.stream.internal
 
+import work.socialhub.kslack.Slack
 import work.socialhub.kslack.api.methods.helper.JsonHelper
 import work.socialhub.kslack.entity.event.*
 import work.socialhub.kslack.stream.SlackStreamListener
@@ -16,12 +17,12 @@ import kotlin.js.JsExport
 class SocketModeClient(
     private val token: String,
     private val listener: SlackStreamListener,
+    private val apiUrl: String = Slack.ENDPOINT_URL_PREFIX,
 ) {
 
     companion object {
         private const val INITIAL_RECONNECT_DELAY_MS = 1000L
         private const val MAX_RECONNECT_DELAY_MS = 30000L
-        private const val SOCKET_MODE_ENDPOINT = "https://slack.com/api/apps.connections.open"
     }
 
     @Volatile
@@ -70,7 +71,7 @@ class SocketModeClient(
 
     private suspend fun fetchSocketModeUrl(): String {
         val response = HttpRequest()
-            .url(SOCKET_MODE_ENDPOINT)
+            .url("${apiUrl}apps.connections.open")
             .header("Authorization", "Bearer $token")
             .forceApplicationFormUrlEncoded(true)
             .post()


### PR DESCRIPTION
Allow SlackFactory to accept a custom apiUrl so that requests can be routed through an alternative base URL.